### PR TITLE
Implements compare for binary searching

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "TSFoster/elm-uuid",
     "summary": "Create and manage UUIDs",
     "license": "BSD-3-Clause",
-    "version": "4.1.0",
+    "version": "4.2.0",
     "exposed-modules": [
         "UUID"
     ],

--- a/src/UUID.elm
+++ b/src/UUID.elm
@@ -7,7 +7,7 @@ module UUID exposing
     , fromBytes, decoder, toBytes, encoder
     , toString, toRepresentation, Representation(..)
     , jsonDecoder, toValue, toValueWithRepresentation
-    , version
+    , version, compare
     , nilBytes, isNilBytes, nilString, isNilString, nilRepresentation
     )
 
@@ -86,7 +86,7 @@ commonly named GUIDs. Additionally, some APIs do not use the dashes.
 
 ## Inspecting UUIDs
 
-@docs version
+@docs version, compare
 
 
 ## The Nil UUID
@@ -466,6 +466,30 @@ isVariant1 : UUID -> Bool
 isVariant1 (UUID _ _ c _) =
     -- The 2 most significant bits of c have to be 0b10 for it to be Variant 1
     Bitwise.shiftRightZfBy 30 c == 2
+
+
+{-| Returns the relative ordering of two `UUID`s. The main use-case of this
+function is helping in binary-searching algorithms.
+Mimics the [`elm/core`'s `compare`](https://package.elm-lang.org/packages/elm/core/1.0.5/Basics#compare).
+-}
+compare : UUID -> UUID -> Order
+compare (UUID a1 b1 c1 d1) (UUID a2 b2 c2 d2) =
+    case Basics.compare a1 a2 of
+        EQ ->
+            case Basics.compare b1 b2 of
+                EQ ->
+                    case Basics.compare c1 c2 of
+                        EQ ->
+                            Basics.compare d1 d2
+
+                        c ->
+                            c
+
+                b ->
+                    b
+
+        a ->
+            a
 
 
 


### PR DESCRIPTION
## What?

Implements a `compare` function using the four internal integers directly.

## Why?

All the entities in all my projects use UUID as key-column/identifiers. The number of places where I used `UUID.toString` in `Dict`, `Set`, or any de-duplication after two years became scary. And retrieving those types from `Dict.keys` was a pain in the @ss.

So I decided: Maybe it's time to have dedicated types instead of using Evan's Dict/Set. But all that we're missing right now is this.

## Documentation Preview

![Doc preview](https://user-images.githubusercontent.com/1368952/163871333-a6324f65-f28b-43eb-b218-fbbd58415acb.png)
